### PR TITLE
Fix prefixed ordinal value

### DIFF
--- a/values/src/dimension.rs
+++ b/values/src/dimension.rs
@@ -94,7 +94,7 @@ impl OrdinalValue {
     pub fn prefixed(self) -> OrdinalValue {
         OrdinalValue {
             value: self.value,
-            prefixed: false,
+            prefixed: true,
         }
     }
 }


### PR DESCRIPTION
I seem that the `OrdinalValue::prefixed` method does not return a prefixed ordinal value.
Am I right?