### PR TITLE
Support for decimal numbers and amounts with cents

### DIFF
--- a/grammar/fr/src/rules.rs
+++ b/grammar/fr/src/rules.rs
@@ -1844,18 +1844,21 @@ pub fn rules_numbers(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
         b.reg(r#"virgule|point"#)?,
         number_check!(|number: &NumberValue| !number.suffixed()),
         |a, _, b| {
+            let power = b.value().value().to_string().chars().count();
+            let coeff = 10.0_f32.powf(-1.0 * power as f32);
             Ok(FloatValue {
-                value: b.value().value() * 0.1 + a.value().value(),
+                value: b.value().value() * coeff + a.value().value(),
                 ..FloatValue::default()
             })
     });
     b.rule_4("number dot number",
          number_check!(|number: &NumberValue| !number.prefixed()),
          b.reg(r#"virgule|point"#)?,
-         b.reg(r#"(?:(?:zero )*(?:zero))"#)?,
+         b.reg(r#"(?:(?:z[eé]ro )*(?:z[eé]ro))"#)?,
          number_check!(|number: &NumberValue| !number.suffixed()),
          |a, _, zeros, b| {
-             let coeff = 10.0_f32.powf(-1.0 * (zeros.group(0).split_whitespace().count() + 1) as f32);
+             let power = zeros.group(0).split_whitespace().count() + 1;
+             let coeff = 10.0_f32.powf(-1.0 * power as f32);
              Ok(FloatValue {
                  value: b.value().value() * coeff + a.value().value(),
                  ..FloatValue::default()


### PR DESCRIPTION
This is mostly about checking sync with https://github.com/snipsco/snips-grammars/pull/152 since support was already there.
However the resolution of decimal numbers was faulty, now fixed but resolution of decimals < 1 has  rounding issue.

Closing - PR should be properly about decimal resolution and should fix all languages.