### PR TITLE
Update version to 0.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,10 @@ All notable changes to this project will be documented in this file.
 - Fix resolution of decimal numbers in textual form.
 
 [0.17.7]: https://github.com/snipsco/rustling-ontology/compare/0.17.6...0.17.7
+
+
+## [0.17.6] - 2018-12-13
+### Changed
+- Fuller coverage of Spanish and Italian
+
+[0.17.6]: https://github.com/snipsco/rustling-ontology/compare/0.17.5...0.17.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.17.6] - 2018-12-13
+## [0.17.7] - 2019-01-17
 ### Changed
-- Fuller coverage of Spanish and Italian
+- Fix resolution of decimal numbers in textual form.
 
-[0.17.6]: https://github.com/snipsco/rustling-ontology/compare/0.17.5...0.17.6
+[0.17.7]: https://github.com/snipsco/rustling-ontology/compare/0.17.6...0.17.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 build = "build.rs"
 

--- a/cli-debug/Cargo.toml
+++ b/cli-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-cli-debug"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>", "Mathieu Poumeyrol <kali@zoy.org>"]
 
 [dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-cli"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>", "Mathieu Poumeyrol <kali@zoy.org>"]
 
 [dependencies]

--- a/grammar/Cargo.toml
+++ b/grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-grammar"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/de/Cargo.toml
+++ b/grammar/de/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-de"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/en/Cargo.toml
+++ b/grammar/en/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-en"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/es/Cargo.toml
+++ b/grammar/es/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-es"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/fr/Cargo.toml
+++ b/grammar/fr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-fr"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/it/Cargo.toml
+++ b/grammar/it/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-it"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/ja/Cargo.toml
+++ b/grammar/ja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-ja"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["Anaïs <anais@chanclu.fr>"]
 
 [dependencies]

--- a/grammar/ko/Cargo.toml
+++ b/grammar/ko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-ko"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/grammar/zh/Cargo.toml
+++ b/grammar/zh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-zh"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/json-utils/Cargo.toml
+++ b/json-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-json-utils"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["Hubert De La Jonquiere <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/moment/Cargo.toml
+++ b/moment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-moment"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 
 [dependencies]

--- a/values/Cargo.toml
+++ b/values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-values"
-version = "0.17.6"
+version = "0.17.7"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 
 [dependencies]


### PR DESCRIPTION
## [0.17.7] - 2019-01-17
### Changed
- Fix resolution of decimal numbers in textual form.

[0.17.7]: https://github.com/snipsco/rustling-ontology/compare/0.17.6...0.17.7