### PR TITLE
Fix/fr add duration vocab

### DIFF
--- a/grammar/fr/src/rules.rs
+++ b/grammar/fr/src/rules.rs
@@ -312,17 +312,12 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
              |duration, _| Ok(duration.value().clone().precision(Precision::Exact))
     );
     b.rule_2("pendant <duration>",
-             b.reg(r#"pendant|durant|pour(?: une dur[eé]e? d['e])?"#)?,
+             b.reg(r#"pendant|durant|pour"#)?,
              duration_check!(),
              |_, duration| Ok(duration.value().clone().prefixed())
     );
     b.rule_2("une durée de <duration>",
-             b.reg(r#"une durée d(?:e|'une?)?"#)?,
-             duration_check!(),
-             |_, duration| Ok(duration.value().clone().prefixed())
-    );
-    b.rule_2("une durée de <duration>",
-             b.reg(r#"une durée d['e]"#)?,
+             b.reg(r#"une dur[ée]e d['e]"#)?,
              duration_check!(),
              |_, duration| Ok(duration.value().clone().prefixed())
     );

--- a/grammar/fr/src/rules.rs
+++ b/grammar/fr/src/rules.rs
@@ -288,9 +288,24 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
         |duration, _| duration.value().in_present()
     );
     b.rule_2("environ <duration>",
-             b.reg(r#"environ"#)?,
+             b.reg(r#"environ|approximativement|à peu près|presque"#)?,
              duration_check!(),
              |_, duration| Ok(duration.value().clone().precision(Precision::Approximate))
+    );
+    b.rule_2("<duration> environ",
+             duration_check!(),
+             b.reg(r#"environ|approximativement|à peu près"#)?,
+             |duration, _| Ok(duration.value().clone().precision(Precision::Approximate))
+    );
+    b.rule_2("exactement <duration> ",
+             b.reg(r#"exactement|précisément"#)?,
+             duration_check!(),
+             |_, duration| Ok(duration.value().clone().precision(Precision::Exact))
+    );
+    b.rule_2("<duration> exactement",
+             duration_check!(),
+             b.reg(r#"exactement|précisément|pile"#)?,
+             |duration, _| Ok(duration.value().clone().precision(Precision::Exact))
     );
     b.rule_2("pendant <duration>",
              b.reg(r#"pendant|durant|pour(?: une dur[eé]e? d['e])?"#)?,
@@ -899,6 +914,11 @@ pub fn rules_time(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
     b.rule_2("<time-of-day> heures",
              time_check!(form!(Form::TimeOfDay(TimeOfDayForm::Hour { .. }))),
              b.reg(r#"h\.?(?:eure)?s?"#)?,
+             |a, _| Ok(a.value().clone().not_latent())
+    );
+    b.rule_2("<time-of-day> (heures) pile",
+             time_check!(form!(Form::TimeOfDay(TimeOfDayForm::Hour { .. }))),
+             b.reg(r#"pile"#)?,
              |a, _| Ok(a.value().clone().not_latent())
     );
     b.rule_2("à|vers <time-of-day>",

--- a/grammar/fr/src/rules.rs
+++ b/grammar/fr/src/rules.rs
@@ -209,6 +209,10 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
         b.reg(r#"an(?:n[ée]e?)?s?"#)?,
         |_| Ok(UnitOfDurationValue::new(Grain::Year))
     );
+    b.rule_1_terminal("trimestre (unit-of-duration)",
+        b.reg(r#"trimestres?"#)?,
+        |_| Ok(UnitOfDurationValue::new(Grain::Quarter))
+    );
     b.rule_1_terminal("un quart heure",
         b.reg(r#"(1/4\s?h(?:eure)?|(?:un|1) quart d'heure)"#)?,
         |_| Ok(DurationValue::new(PeriodComp::minutes(15).into()))
@@ -312,6 +316,16 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
              duration_check!(),
              |_, duration| Ok(duration.value().clone().prefixed())
     );
+    b.rule_2("une durée de <duration>",
+             b.reg(r#"une durée d(?:e|'une?)?"#)?,
+             duration_check!(),
+             |_, duration| Ok(duration.value().clone().prefixed())
+    );
+    b.rule_2("une durée de <duration>",
+             b.reg(r#"une durée d['e]"#)?,
+             duration_check!(),
+             |_, duration| Ok(duration.value().clone().prefixed())
+    );
     b.rule_2("il y a <duration>",
              b.reg(r#"il y a"#)?,
              duration_check!(),
@@ -367,6 +381,10 @@ pub fn rules_cycle(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
     b.rule_1("année (cycle)",
              b.reg(r#"an(?:n[ée]e?)?s?"#)?,
              |_| CycleValue::new(Grain::Year)
+    );
+    b.rule_1_terminal("trimestre (cycle)",
+             b.reg(r#"trimestres?"#)?,
+             |_| CycleValue::new(Grain::Quarter)
     );
     b.rule_2("ce|dans le <cycle>",
              b.reg(r#"(?:cet?t?e?s?)|(?:dans l[ae']? ?)"#)?,

--- a/grammar/fr/src/training.rs
+++ b/grammar/fr/src/training.rs
@@ -248,14 +248,14 @@ pub fn examples_time(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 }
 
 pub fn examples_durations(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    example!(v, check_duration!([0, 0, 0, 0, 2]), "pendant deux heures", "durant deux heures");
+    example!(v, check_duration!([0, 0, 0, 0, 2]), "pendant deux heures", "durant deux heures", "pour une durée de deux heures", "une durée de deux heures");
     example!(v, check_duration!([0, 0, 0, 1]), "pendant un jour", "une journée");
     example!(v, check_duration!([0, 1, 0]), "durant un mois");
     example!(v, check_duration!([1]), "durant une année");
     example!(v, check_duration!([0, 0, 0, 0, 0, 1, 3]), "pendant une minute et trois secondes");
-    example!(v, check_duration!([0, 0, 0, 0, 1, 30], Precision::Approximate), "environ une heure trente", "environ 1h30");
+    example!(v, check_duration!([0, 0, 0, 0, 1, 30], Precision::Approximate), "environ une heure trente", "environ 1h30", "approximativement une heure trente");
     example!(v, check_duration!([0, 0, 0, 0, 0, 15], Precision::Approximate), "pendant environ un quart d'heure", "environ 1/4h");
-    example!(v, check_duration!([0, 0, 0, 0, 1]), "durant une heure");
+    example!(v, check_duration!([0, 0, 0, 0, 1]), "durant une heure", "pendant exactement une heure");
     example!(v, check_duration!([0, 0, 2]), "pendant 2 semaines");
 }
 


### PR DESCRIPTION
- Add precision variations in Duration (ex: "à peu près", "exactement", etc)
- Add expressions: "une durée de .." + <duration>
- Add cycle "trimestre"
- Add expression "pile" for Time (ex: "deux heures pile")
- Add corresponding training examples