### PR TITLE
Release 0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.19.3]
 ### Fixed
 - Remove Chinese training examples causing issues on raspbian and windows [#205](https://github.com/snipsco/rustling-ontology/pull/205)
 - Fix float parsing for all languages [#203](https://github.com/snipsco/rustling-ontology/pull/203)
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Fuller coverage of Spanish and Italian
 
+[0.19.3]: https://github.com/snipsco/rustling-ontology/compare/0.19.2...0.19.3
 [0.19.2]: https://github.com/snipsco/rustling-ontology/compare/0.19.1...0.19.2
 [0.19.1]: https://github.com/snipsco/rustling-ontology/compare/0.19.0...0.19.1
 [0.19.0]: https://github.com/snipsco/rustling-ontology/compare/0.18.1...0.19.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 build = "build.rs"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rustling-ontology
-[![Build Status](https://travis-ci.org/snipsco/rustling-ontology.svg?branch=develop)](https://travis-ci.org/snipsco/rustling-ontology)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/snipsco/rustling-ontology?branch=develop&svg=true)](https://ci.appveyor.com/project/snipsco/rustling-ontology)
+[![Build Status](https://travis-ci.org/snipsco/rustling-ontology.svg?branch=master)](https://travis-ci.org/snipsco/rustling-ontology)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/snipsco/rustling-ontology?branch=master&svg=true)](https://ci.appveyor.com/project/snipsco/rustling-ontology)
 
 Probabilistic parser for entity detection based on Rustling (https://github.com/snipsco/rustling)
 

--- a/cli-debug/Cargo.toml
+++ b/cli-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-cli-debug"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>", "Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2018"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-cli"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>", "Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2018"
 

--- a/grammar/Cargo.toml
+++ b/grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-grammar"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/de/Cargo.toml
+++ b/grammar/de/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-de"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/en/Cargo.toml
+++ b/grammar/en/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-en"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/es/Cargo.toml
+++ b/grammar/es/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-es"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/fr/Cargo.toml
+++ b/grammar/fr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-fr"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/it/Cargo.toml
+++ b/grammar/it/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-it"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/ja/Cargo.toml
+++ b/grammar/ja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-ja"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Anaïs <anais@chanclu.fr>"]
 edition = "2018"
 

--- a/grammar/ko/Cargo.toml
+++ b/grammar/ko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-ko"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/grammar/pt/Cargo.toml
+++ b/grammar/pt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-pt"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <rosa.stern@snips.ai>"]
 edition = "2018"
 

--- a/grammar/zh/Cargo.toml
+++ b/grammar/zh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-zh"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/json-utils/Cargo.toml
+++ b/json-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-json-utils"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Hubert De La Jonquiere <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/moment/Cargo.toml
+++ b/moment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-moment"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["hdlj <hubert.delajonquiere@snips.net>"]
 edition = "2018"
 

--- a/values/Cargo.toml
+++ b/values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustling-ontology-values"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2018"
 


### PR DESCRIPTION
### Fixed
- Remove Chinese training examples causing issues on raspbian and windows [#205](https://github.com/snipsco/rustling-ontology/pull/205)
- Fix float parsing for all languages [#203](https://github.com/snipsco/rustling-ontology/pull/203)
- Add various improvements in all languages [#203](https://github.com/snipsco/rustling-ontology/pull/203)