### PR TITLE
Change the API for the ResolverContext and the Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unrelease]
+
+### Changed
+- Rename on Resolver Context the `new` by `for_reference`
+
+### Added 
+- `ResolverContext::new` to build a context with a reference, min and max interval.
+
 ## [0.19.3]
 ### Fixed
 - Remove Chinese training examples causing issues on raspbian and windows [#205](https://github.com/snipsco/rustling-ontology/pull/205)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unrelease]
 
 ### Changed
-- Rename on Resolver Context the `new` by `for_reference`
+- Rename  `ResolverContext::new` by `ResolverContext::for_reference`
 
 ### Added 
 - `ResolverContext::new` to build a context with a reference, min and max interval.

--- a/cli-debug/src/main.rs
+++ b/cli-debug/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     match matches.subcommand() {
         ("parse", Some(matches)) => {
             let sentence = matches.value_of("sentence").unwrap().to_lowercase();
-            let decoder = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+            let decoder = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
             let rules = grammar::rules(lang).unwrap();
             let matches = rules.apply_all(&*sentence).unwrap();
             let mut table = Table::new();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
             let utterances: Vec<Utterance> = partial_utterances.into_iter()
                 .map(|it| {
                   if it.keep() && (it.value.is_none() || force_resolution) {
-                      let context = ResolverContext::new(Interval::starting_at(default_context, Grain::Second));
+                      let context = ResolverContext::for_reference(Interval::starting_at(default_context, Grain::Second));
                       let entities = parser.parse(it.phrase.to_lowercase().as_str(), &context).unwrap();
                       let full_match = entities
                         .into_iter()
@@ -180,7 +180,7 @@ fn main() {
                         .collect::<Vec<_>>()
                 });
             let utterances: Vec<Utterance> = {
-              let file = ::std::fs::File::open(input_path).map_err(|e| format!("Could not open input file at path: {}, with error {}", input_path, e)).unwrap();;
+              let file = ::std::fs::File::open(input_path).map_err(|e| format!("Could not open input file at path: {}, with error {}", input_path, e)).unwrap();
               serde_json::from_reader(&file).unwrap()
             };
             let parser = build_parser(lang).unwrap();
@@ -189,7 +189,7 @@ fn main() {
             let output: Vec<TestOutput> = utterances.into_iter()
                 .map(|utterance| {
                   if utterance.keep() {
-                      let context = ResolverContext::new(Interval::starting_at(default_context, Grain::Second));
+                      let context = ResolverContext::for_reference(Interval::starting_at(default_context, Grain::Second));
                       let entities = if let Some(ref kinds) = kinds {
                           parser.parse_with_kind_order(utterance.phrase.to_lowercase().as_str(), &context, &kinds).unwrap()
                       } else {

--- a/grammar/de/src/training.rs
+++ b/grammar/de/src/training.rs
@@ -76,7 +76,7 @@ pub fn examples_finance(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 }
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 0]), "jetzt", "genau jetzt", "gerade eben");
     example!(v, check_moment!(c, [2013, 2, 12]), "heute", "zu dieser zeit");
     example!(v, check_moment!(c, [2013, 2, 11]), "gestern");

--- a/grammar/en/src/training.rs
+++ b/grammar/en/src/training.rs
@@ -47,7 +47,7 @@ pub fn examples_finance(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 
 // TODO: Sort out and split by datetime subtype
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 0]), "now", "right now", "just now", "at this time");
     example!(v, check_moment!(c, [2013, 2, 12]), "today");
     example!(v, check_moment!(c, [2013, 2, 11]), "yesterday");

--- a/grammar/es/src/training.rs
+++ b/grammar/es/src/training.rs
@@ -4,7 +4,7 @@ use rustling_ontology_values::dimension::*;
 use rustling_ontology_values::ResolverContext;
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     // Days
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 00]), "ahora", "ahora mismo", "en este preciso momento", "en este preciso istante", "inmediatamente");
     example!(v, check_moment!(c, [2013, 2, 12]), "hoy", "en este momento");

--- a/grammar/fr/src/training.rs
+++ b/grammar/fr/src/training.rs
@@ -47,7 +47,7 @@ pub fn examples_finance(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 }
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 00]), "maintenant", "tout de suite", "en ce moment");
     example!(v, check_moment!(c, [2013, 2, 12]), "aujourd'hui", "ce jour", "dans la journée");
     example!(v, check_moment!(c, [2013, 2, 11]), "hier", "le jour d'avant", "le jour précédent", "la veille");

--- a/grammar/it/src/training.rs
+++ b/grammar/it/src/training.rs
@@ -4,7 +4,7 @@ use rustling_ontology_values::dimension::*;
 use rustling_ontology_values::ResolverContext;
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     // Days
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 00]), "ora", "adesso", "in questo momento esatto", "in questo preciso istante");
     example!(v, check_moment!(c, [2013, 2, 12]), "oggi", "in questo momento", "in questa giornata");

--- a/grammar/ja/src/training.rs
+++ b/grammar/ja/src/training.rs
@@ -96,7 +96,7 @@ pub fn examples_durations(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 }
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 10]), "一昨日", "二千十三年二月十日", "前の日曜日", "先週の日曜日");
     example!(v, check_moment!(c, [2013, 2, 11]), "昨日", "前の日", "前日");
     example!(v, check_moment!(c, [2013, 2, 13]), "明日", "次の日", "二千十三年二月十三日", "今週の水曜日", "バレンタインデーの前の日");

--- a/grammar/ko/src/training.rs
+++ b/grammar/ko/src/training.rs
@@ -29,7 +29,7 @@ pub fn examples_temperature(v: &mut Vec<::rustling::train::Example<Dimension>>) 
 }
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 0]), "방금", "지금");
     example!(v, check_moment!(c, [2013, 2, 12]), "오늘");
     example!(v, check_moment!(c, [2013, 2, 11]), "어제");

--- a/grammar/pt/src/training.rs
+++ b/grammar/pt/src/training.rs
@@ -87,7 +87,7 @@ pub fn examples_finance(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 }
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
 
     // Days
     example!(v, check_moment!(c, [2013, 2, 12, 4, 30, 00]), "agora", "agora mesmo", "neste exato momento", "neste momento");

--- a/grammar/zh/src/training.rs
+++ b/grammar/zh/src/training.rs
@@ -13,7 +13,7 @@ pub fn examples_durations(v: &mut Vec<::rustling::train::Example<Dimension>>) {
 
 
 pub fn examples_datetime(v: &mut Vec<::rustling::train::Example<Dimension>>) {
-    let c = ResolverContext::new(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
+    let c = ResolverContext::for_reference(Interval::starting_at(Moment(Local.ymd(2013, 2, 12).and_hms(4, 30, 0)), Grain::Second));
     example!(v, check_moment!(c, [2013, 2, 10]), "前天", "前日", "上周日", "上星期天", "上礼拜天", "上週日", "上星期天", "上禮拜天", "上禮拜日");
     example!(v, check_moment!(c, [2013, 2, 10]), "周日, 二月十号", "星期天, 二月十号", "礼拜天, 二月十号", "週日, 二月十號", "星期天, 二月十號", "禮拜天, 二月十號", "禮拜日, 二月十號");
     example!(v, check_moment!(c, [2013, 2, 13]),"星期三", "周三", "礼拜三", "禮拜三", "週三", "明天", "明日", "聽日");

--- a/moment/src/interval_constraints.rs
+++ b/moment/src/interval_constraints.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::ops;
 use std::rc::Rc;
 
-#[derive(Clone, PartialEq, new)]
+#[derive(Clone, PartialEq)]
 pub struct Context<T: TimeZone> {
     pub reference: Interval<T>,
     pub min: Interval<T>,
@@ -42,6 +42,19 @@ impl<T: TimeZone> Context<T>
 where
     <T as TimeZone>::Offset: Copy,
 {
+    /// Returns a context based on the given intervals. The caller needs to be careful with 32bits 
+    /// operating system. 
+    pub fn new(reference: Interval<T>, min: Interval<T>, max: Interval<T>) -> Context<T> {
+        Context {
+            reference,
+            min,
+            max,
+        }
+    }
+
+    /// Returns a context based on the given reference date. To avoid undefined behaviour for 
+    /// 32 bits operating system. The max and min date restricted to 1970 and 2038. To avoid this 
+    /// restriction, `new` function should be used. 
     pub fn for_reference(now: Interval<T>) -> Context<T> {
         // TODO: Should be refactor with the min, max date offer by chrono crate
         let now_end = now.end_moment();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,7 +35,7 @@ pub fn extract_node_features(
     let rules_feat = node
         .children
         .iter()
-        .map({ |child| child.rule_sym })
+        .map( |child| child.rule_sym )
         .collect::<Vec<_>>();
 
     let mut features = vec![Feat::Rules(rules_feat)];
@@ -46,7 +46,7 @@ pub fn extract_node_features(
     let children_features = node
         .children
         .iter()
-        .map({ |child| extract_node_features(child) })
+        .map(|child| extract_node_features(child))
         .collect();
 
     rustling::Input {

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -12,7 +12,7 @@ pub fn run_json_test<P: AsRef<path::Path>>(lang: Lang, path: P) {
     let utterances: Vec<Utterance> = utterances.into_iter().filter(|it| it.keep()).collect();
     let parser = build_parser(lang).unwrap();
     for utterance in utterances {
-        let context = ResolverContext::new(Interval::starting_at(utterance.context, moment::Grain::Second));
+        let context = ResolverContext::for_reference((Interval::starting_at(utterance.context, moment::Grain::Second));
         let entities = parser.parse(utterance.phrase.to_lowercase().as_str(), &context).unwrap();
         assert_eq!(entities.len(), 1, "Only one match was exepcted for this sentence: {:?}", utterance.phrase.as_str());
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -12,7 +12,7 @@ pub fn run_json_test<P: AsRef<path::Path>>(lang: Lang, path: P) {
     let utterances: Vec<Utterance> = utterances.into_iter().filter(|it| it.keep()).collect();
     let parser = build_parser(lang).unwrap();
     for utterance in utterances {
-        let context = ResolverContext::for_reference((Interval::starting_at(utterance.context, moment::Grain::Second));
+        let context = ResolverContext::for_reference(Interval::starting_at(utterance.context, moment::Grain::Second));
         let entities = parser.parse(utterance.phrase.to_lowercase().as_str(), &context).unwrap();
         assert_eq!(entities.len(), 1, "Only one match was exepcted for this sentence: {:?}", utterance.phrase.as_str());
 

--- a/values/src/context.rs
+++ b/values/src/context.rs
@@ -36,12 +36,21 @@ pub struct ResolverContext {
 impl ResolverContext {
     pub fn from_secs(secs: i64) -> ResolverContext {
         let anchor = Interval::starting_at(Moment(Local.timestamp(secs, 0)), Grain::Second);
-        ResolverContext::new(anchor)
+        ResolverContext::for_reference(anchor)
     }
 
-    pub fn new(now: Interval<Local>) -> ResolverContext {
+    /// Returns a ResolverContext for the given interval. This API is working for 32bits and 64bits 
+    /// operating system by supporting dates only between 1970 and 2038
+    pub fn for_reference(now: Interval<Local>) -> ResolverContext {
         ResolverContext {
             ctx: Context::for_reference(now),
+        }
+    }
+
+    /// Returns a ResolverContext with the given intervals. No restrictions is applied. 
+    pub fn new(now: Interval<Local>, min: Interval<Local>, max: Interval<Local>) -> ResolverContext {
+        ResolverContext {
+            ctx: Context::new(now, min, max)
         }
     }
 }


### PR DESCRIPTION
The current API had a restriction on the context: no support for dates under 1970 and above 2038. This PR introduces a new API to bypass this restriction for 64 bits operating system